### PR TITLE
Fix encoding error

### DIFF
--- a/pysheng/download.py
+++ b/pysheng/download.py
@@ -175,9 +175,9 @@ def main(args):
                  args.noredownload)):
             open(output_path, "wb").write(image_data)
             if not args.quiet:
-                print 'Downloaded {}'.format(output_path)
+                print 'Downloaded {}'.format(output_path.encode('utf-8'))
         elif not args.quiet:
-            print 'Output file {} exists'.format(output_path)
+            print 'Output file {} exists'.format(output_path.encode('utf-8'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If the book title or the author names include non-ascii characters, the program crashes, e.g., with
`UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 7: ordinal not in range(128).`
The proposed tiny change fixes the issue.